### PR TITLE
Announce Toggle

### DIFF
--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -320,7 +320,7 @@ function generateMaybeOutput(user)
 			local userMaxHealth = UnitHealthMax(user)
 			local msgAmount = round(amount / 1000000,1)
 			local pct = Round(amount / userMaxHealth * 100)
-			if pct >= hardMinPct and pct >= minPct then
+			if pct >= hardMinPct and pct >= minPct and EHLoud then
 				msg = msg.."for "..msgAmount.."mil ("..pct.."%)."
 				maybeSendChatMessage(msg)
 			end
@@ -328,24 +328,43 @@ function generateMaybeOutput(user)
 	return func
 end
 
+SLASH_ELITISMHELPER1 = "/eh"
+
 SlashCmdList["ELITISMHELPER"] = function(msg,editBox)
 	if msg == "activeuser" then
 		print("activeUser is "..activeUser)
 		if activeUser == playerUser then
 			print("You are the activeUser")
 		end
+		
 	elseif msg == "resync" then
 		ElitismFrame:RebuildTable()
+		
 	elseif msg == "table" then
 		for k,v in pairs(Users) do
 			print(k.." ;;; "..v)
 		end
+		
 	elseif msg == "eod" then
 		ElitismFrame:CHALLENGE_MODE_COMPLETED()
+		
+	elseif msg == "on" or msg == "enable" then
+		if EHLoud then
+			print("ElitismHelper: Damage notifications are already enabled.")
+		else
+			EHLoud = true
+			print("ElitismHelper: All damage notifications enabled.")
+		end
+		
+	elseif msg == "off" or msg == "disable" then
+		if not EHLoud then
+			print("ElitismHelper: Damage notifications are already disabled.")
+		else
+			EHLoud = false
+			print("ElitismHelper: Will only announce at the end of the dungeon.")
+		end
 	end
 end
-
-SLASH_ELITISMHELPER1 = "/eh"
 
 function maybeSendAddonMessage(prefix, message)
 	if IsInGroup() and not IsInGroup(2) and not IsInRaid() then
@@ -474,9 +493,9 @@ end
 
 function ElitismFrame:AuraApply(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, auraType, auraAmount)
 	if (Auras[spellId] or (AurasNoTank[spellId] and UnitGroupRolesAssigned(dstName) ~= "TANK")) and UnitIsPlayer(dstName)  then
-		if auraAmount then
+		if auraAmount and EHLoud then
 			maybeSendChatMessage("<EH> "..dstName.." got hit by "..GetSpellLink(spellId)..". "..auraAmount.." Stacks.")
-		else
+		elseif EHLoud then
 			maybeSendChatMessage("<EH> "..dstName.." got hit by "..GetSpellLink(spellId)..".")
 		end
 	end

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -402,6 +402,10 @@ function ElitismFrame:ADDON_LOADED(event,addon)
 	if addon == "ElitismHelper" then
 		ElitismFrame:RebuildTable()
 	end
+	
+	if not EHLoud then
+		EHLoud = true
+	end
 end
 
 function ElitismFrame:GROUP_ROSTER_UPDATE(event,...)

--- a/ElitismHelper.toc
+++ b/ElitismHelper.toc
@@ -2,4 +2,5 @@
 ## Title: ElitismHelper
 ## Version: 0.7.8
 ## Notes: Helps with being an elitist by calling out fails
+## SavedVariables: EHLoud
 ElitismHelper.lua


### PR DESCRIPTION
Adds the ability to enable/disable the active announcements of damage
taken utilizing /eh [on|off] or /eh [enable|disable].

I've added this due to wanting to disable the announcements while running higher keys with a core group of friends without having to disable the addon and reloading the UI.