### PR TITLE
New feature, Ability update

### DIFF
--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -485,6 +485,15 @@ function maybeSendChatMessage(message)
 	end
 end
 
+function delayMaybeSendChatMessage(message, delay)
+	C_Timer.After(
+		delay,
+		function()
+			maybeSendChatMessage(message)
+		end
+	)
+end
+
 function ElitismFrame:RebuildTable()
 	Users = {}
 	activeUser = nil

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -14,7 +14,7 @@ local Spells = {
 
         -- Reaping
 	[288858] = 20,          -- Expel Soul (Environment)
-	[288694] = 20,          -- Shadow Smash (Lost Soul)
+	[296142] = 20,          -- Shadow Smash (Lost Soul) -- fixed ID
 	--[288693] = 20,          -- Grave Bolt (Tormented Soul)
 	
 	-- Affixes

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -529,7 +529,8 @@ function ElitismFrame:CHALLENGE_MODE_COMPLETED(event,...)
 	local count = 0
 	for _ in pairs(CombinedFails) do count = count + 1 end
 	if count == 0 then
-		maybeSendChatMessage("Thank you for travelling with ElitismHelper. No failure damage was taken this run.")
+		print("No Damage?");
+		--maybeSendChatMessage("Thank you for travelling with ElitismHelper. No failure damage was taken this run.")
 		return
 	else
 		maybeSendChatMessage("Thank you for travelling with ElitismHelper. Amount of failure damage:")
@@ -545,6 +546,7 @@ end
 
 function ElitismFrame:CHALLENGE_MODE_START(event,...)
 	CombinedFails = {}
+	FailByAbility = {}
 	print("Failure damage now being recorded.")
 end
 


### PR DESCRIPTION
(UNDR) Indigestion is now tagged as non-Tank fail damage as it's cast towards the Tank.
(ML) Mines are no longer considered fail damage, most of the time it's desired to take the hit.

(REAPING)
Removed Grave Bolt as fail damage souce
Added damage from Expel Soul (corrected ID)

Feature:
Tracks damage ticks and amount per source
show list of all players to self with /eh list

Damage tables are now only reset on start so you can view it anytime after doing the dungeon.

show list of player to default output with
/eh list unitID

eg: "/eh list player" for self
"/eh list target" for current target
"/eh list dude-server" shows for dude on server
"/eh list dude" shows for dude on your server