### PR TITLE
Season 2 updates

### DIFF
--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -49,7 +49,6 @@ local Spells = {
 	-- Mists of Tirna Scithe
 	[321968] = 20,		-- Bewildering Pollen (Tirnenn Villager)
 	[323137] = 20,		-- Bewildering Pollen (Tirnenn Villager)
-	[323250] = 20,		-- Anima Puddle (Droman Oulfarran)
 	[325027] = 20,		-- Bramble Burst (Drust Boughbreaker)
 	[326022] = 20,		-- Acid Globule (Spinemaw Gorger)
 	[340300] = 20,		-- Tongue Lashing (Mistveil Gorgegullet)

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -73,17 +73,15 @@ local Spells = {
 	[323118] = 20,      -- Blood Barrage (Hakkar the Soulflayer)
 	[331933] = 20,		-- Haywire (Defunct Dental Drill)
 	[332157] = 20,      -- Spinning Up (Headless Client)
-	[323569] = 20,   	-- Spilled Essence (Environement)
-	[320830] = 20,		-- Mechanical Bomb Squirrel
+	[323569] = 20,   	-- Spilled Essence (Environment)
 	[323136] = 20,      -- Anima Starstorm (Runestag Elderhorn)
 	[323992] = 20,      -- Echo Finger Laser X-treme (Millificent Manastorm)
 			
 	[320723] = 20,		-- Displaced Blastwave (Dealer Xy'exa)
 	[320232] = 20,      -- Explosive Contrivance (Dealer Xy'exa)
 	[334913] = 20,		-- Master of Death (Mueh'zala)
-	[327427] = 20,		-- Shattered Dominion (Mueh'zala)
 	[325691] = 20,      -- Cosmic Collapse (Mueh'zala)
-	[335000] = 20,		-- Stellar cloud (Mueh'zala)
+	[335000] = 20,		-- Stellar Cloud (Mueh'zala)
 	
 	
 	-- Spires of Ascension
@@ -141,12 +139,12 @@ local Spells = {
 	[319120] = 20, 		-- Putrid Bile (Gushing Slime)
 	[327233] = 20, 		-- Belch Plague (Plagebelcher)
 	[320519] = 20, 		-- Jagged Spines (Blighted Spinebreaker)
-	[328501] = 20,		-- Plagued Bomb (Environement)
+	[328501] = 20,		-- Plagued Bomb (Environment)
 	[324667] = 20,		-- Slime Wave (Globgrog)
 	[626242] = 20,		-- Slime Wave (Globgrog)
 	[333808] = 20,		-- Oozing Outbreak (Doctor Ickus)
 	[329217] = 20,		-- Slime Lunge (Doctor Ickus)
-	[322475] = 20,		-- Plague Crash (Environement Margrave Stradama)
+	[322475] = 20,		-- Plague Crash (Environment Margrave Stradama)
 	
 	-- Theater of Pain
 	[337037] = 20,		-- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
@@ -184,19 +182,21 @@ local Spells = {
 	[325885] = 20,      -- Anguished Cries (Z'rali)
 	[334615] = 20,		-- Sweeping Slash (Head Custodian Javlin)
 	[322212] = 20,		-- Growing Mistrust (Vestige of Doubt)
-	[328494] = 20, 		-- Sintouched Anima (Environement)
+	[328494] = 20, 		-- Sintouched Anima (Environment)
 	[323810] = 20,		-- Piercing Blur (General Kaal)
 	
-	-- Hall of Atonement 
+	-- Halls of Atonement 
 	[325523] = 20,		-- Deadly Thrust (Depraved Darkblade)
 	[325799] = 20,		-- Rapid Fire (Depraved Houndmaster)
 	[326440] = 20,		-- Sin Quake (Shard of Halkias)
 	[326997] = 20,		-- Powerful Swipe (Stoneborn Slasher)
+	[326891] = 20,		-- Anguish (Inquisitor Sigar)
 	
 	[322945] = 20,		-- Heave Debris (Halkias)
 	[324044] = 20,		-- Refracted Sinlight (Halkias)
 	[319702] = 20,		-- Blood Torrent (Echelon)
 	[329340] = 20, 		-- Anima Fountain (High Adjudicator Aleez)
+	[338013] = 20, 		-- Anima Fountain (High Adjudicator Aleez)
 	[323126] = 20, 		-- Telekinetic Collision (Lord Chamberlain)
     [329113] = 20,		-- Telekinteic Onslaught (Lord Chamberlain)
 	[327885] = 20,		-- Erupting Torment (Lord Chamberlain)
@@ -214,6 +214,7 @@ local SpellsNoTank = {
 	
 	-- The Necrotic Wake
 	[324323] = 20,		-- Gruesome Cleave (Skeletal Marauder)
+    [323489] = 20,      -- Throw Cleaver (Flesh Crafter, Stitching Assistant)
 
 	-- Plaguefall
 	
@@ -221,7 +222,7 @@ local SpellsNoTank = {
 	
 	-- Sanguine Depths
 	
-	-- Hall of Atonement 
+	-- Halls of Atonement 
 	--[323001] = 20,      -- Glass Shards (Halkias) This is always unavoidable for tanks but sometimes unavoidable for everyone
 	[322936] = 20,      -- Crumbling Slam (Halkias)
 	[346866] = 20, 		-- Stone Breath (Loyal Stoneborn)
@@ -247,7 +248,7 @@ local Auras = {
 	
 	-- Sanguine Depths
 	
-	-- Hall of Atonement
+	-- Halls of Atonement
 
 	-- Affixes
 	[358973] = 20,        -- Wave of Terror (Season 2 Affix - Varruth)
@@ -257,7 +258,7 @@ local AurasNoTank = {
 }
 
 local MeleeHitters = {
-	[161917] = 20,		-- DEBUG
+	--[161917] = 20,		-- DEBUG
 	[174773] = 20,		-- Spiteful Shade
 }
 

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -36,8 +36,13 @@ local Spells = {
 	[226512] = 20,		-- Sanguine Ichor (Environment)
 	[240448] = 20,      -- Quaking (Environment)
 	[343520] = 20,      -- Storming (Environment)
-	[342494] = 20, 		-- Belligerent Boast(Season 1 Pridefull)
 	[350163] = 20, 		-- Melee (Spiteful Shade)
+
+	[342494] = 20, 		-- Belligerent Boast (Season 1 Prideful)
+	[356414] = 20, 		-- Frost Lance (Season 2 Oros)
+	[358894] = 20, 		-- Cold Snap (Season 2 Oros)
+	[355806] = 20, 		-- Massive Smash (Season 2 Soggodon)
+	[355737] = 20, 		-- Scorching Blast (Season 2 Arkolath)
 	
 	-- Mists of Tirna Scythe
 	[321968] = 20, 		-- Bewildering Pollen (tirnenn Villager)
@@ -47,14 +52,16 @@ local Spells = {
 	[326022] = 20,      -- Acid Globule (Spinemaw Gorger)
 	[340300] = 20,		-- Tongue Lashing (Mistveil Gorgegullet)
 	[340304] = 20,		-- Poisonous Secretions (Mistveil Gorgegullet)
+	[340311] = 20,      -- Crushing Leap (Mistveil Gorgegullet)
 	[331743] = 20,		-- Bucking Rampage (Mistveil Guardian)
+	[331748] = 20,      -- Back Kick (Mistveil Guardian)
 	--id ? [340160] = 20,		-- Radiant Breath (Mistveil Matriarch)
 	
 	--id ? [323177] = 20,		-- Tears of the Forest(Ingra Maloch)
+	[323250] = 20,      -- Anima Puddle (Droman Oulfarran)
 	[321834] = 20,      -- Dodge Ball (Mistcaller)
 	[336759] = 20,      -- Dodge Ball (Mistcaller)
 	[322655] = 20,		-- Acid Expulsion (Tred'Ova)
-	--id ? [322450] = 20,		-- Consumption (Tred'Ova)
 	
 	-- De Other Side
 	[334051] = 20,		-- Erupting Darkness (Death Speaker)
@@ -80,11 +87,7 @@ local Spells = {
 	
 	
 	-- Spires of Ascension
-	[331251] = 20,      -- Deep Connection (Azules / Kin-Tara)
-	[317626] = 20,      -- Maw-Touched Venom (Azules)
-	[323786] = 20,      -- Swift Slice (Kyrian Dark-Praetor)
-	[324662] = 20,      -- Ionized Plasma (Multiple) Can this be avoided?
-	[317943] = 20,      -- Sweeping Blow (Frostsworn Vanguard)
+	--[323786] = 20,      -- Swift Slice (Kyrian Dark-Praetor)
 	[324608] = 20,      -- Charged Stomp (Oryphrion)
 	[323740] = 20,		-- Impact (Forsworn Squad-Leader)
 	[336447] = 20,		-- Crashing Strike (Forsworn Squad-Leader)
@@ -92,16 +95,19 @@ local Spells = {
 	[328466] = 20,		-- Charged Spear (Lakesis / Klotos)
 	[336420] = 20,		-- Diminuendo (Klotos / Lakesis)
 	
-	[321034] = 20,      -- Charged Spear (Kin-Tara)
+	[331251] = 20,      -- Deep Connection (Azules / Kin-Tara)
+	[317626] = 20,      -- Maw-Touched Venom (Azules)
+	-- [321034] = 20,      -- Charged Spear (Kin-Tara) Cannot be avoided
+	[324662] = 20,      -- Ionized Plasma (Multiple) Can this be avoided?
 	[324370] = 20,		-- Attenuated Barrage (Kin-Tara)
 	[324141] = 20,      -- Dark Bolt (Ventunax)
 	[323943] = 20,      -- Run Through (Devos)
 	-- [] = 20,		-- Seed of the Abyss (Devos) ???
 	
 	
-	-- The Necrotic Wakes
+	-- The Necrotic Wake
 	[324391] = 20,		-- Frigid Spikes (Skeletal Monstrosity)
-	-- id ?[324372] = 20,		-- Reaping Winds (Skeletal Monstrosity)
+	[324372] = 20,		-- Reaping Winds (Skeletal Monstrosity)
 	-- id ?[320574] = 20,		-- Shadow Well (Zolramus Sorcerer)
 	[333477] = 20,		-- Gut Slice (Goregrind)
 	
@@ -135,24 +141,27 @@ local Spells = {
 	
 	-- Theater of Pain
 	[337037] = 20,		-- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
-	[336996] = 20, -- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
-	[332708] = 20,		-- Ground Smash (Heavin the breaker)
+	[336996] = 20,      -- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
+	[317605] = 20,      -- Whirlwind (Nekthara the Mangler and Rek the Hardened)
+	[332708] = 20,		-- Ground Smash (Heavin the Breaker)
 	[333297] = 20, 		-- Death Winds (Nefarious Darkspeaker)
 	[331243] = 20,		-- Bone Spikes (Soulforged Bonereaver)
 	[331224] = 20,		-- Bonestorm (Soulforged Bonereaver)
-	[330608] = 20,		-- Vile Eruption (Rancind Gasbag) ?? TODO: Which one is correct?
+	[330608] = 20,		-- Vile Eruption (Rancid Gasbag) ?? TODO: Which one is correct?
 	[330614] = 20,      -- Vile Eruption (Rancid Gasbag) ?? TODO: Which one is correct?
-	[321039] = 20,      -- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)	
+	[321039] = 20,      -- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
+	[321041] = 20,      -- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
 	
 	[317231] = 20, 		-- Crushing Slam (Xav the Unfallen)
 	[339415] = 20,		-- Deafening Crash (Xav the Unfallen)
 	[320729] = 20,		-- Massive Cleave (Xav the Unfallen)
 	[318406] = 20,		-- Tenderizing Smash (Gorechop)
-	[323406] = 20, -- Jagged Gash (Gorechop)
+	[323406] = 20,      -- Jagged Gash (Gorechop)
 	-- id ?[323542] = 20,		-- Oozing (Gorechop)
-	[323681] = 20,		-- Dark Devastation (Mordretha) 
-	[339573] = 20,		-- Echos of Carnage (Mordretha)
-	[339759] = 20,		-- Echos of Carnage (Mordretha)
+	[323681] = 20,		-- Dark Devastation (Mordretha)
+	[339550] = 20,		-- Echo of Battle (Mordretha)
+	[323831] = 20,		-- Death Grasp (Mordretha)
+	[339751] = 20,		-- Ghostly Charge (Mordretha)
 	
 	-- Sanguine Depths
 	[334563] = 20,		-- Volatile Trap (Dreadful Huntmaster)
@@ -173,10 +182,12 @@ local Spells = {
 	[325523] = 20,		-- Deadly Thrust (Depraved Darkblade)
 	[325799] = 20,		-- Rapid Fire (Depraved Houndmaster)
 	[326440] = 20,		-- Sin Quake (Shard of Halkias)
+	[326997] = 20,		-- Powerful Swipe (Stoneborn Slasher)
 	
 	[322945] = 20,		-- Heave Debris (Halkias)
 	[324044] = 20,		-- Refracted Sinlight (Halkias)
 	[319702] = 20,		-- Blood Torrent (Echelon)
+	[329340] = 20, 		-- Anima Fountain (High Adjudicator Aleez)
 	[323126] = 20, 		-- Telekinetic Collision (Lord Chamberlain)
     [329113] = 20,		-- Telekinteic Onslaught (Lord Chamberlain)
 	[327885] = 20,		-- Erupting Torment (Lord Chamberlain)
@@ -184,27 +195,26 @@ local Spells = {
 
 local SpellsNoTank = {
     -- Mists of Tirna Scythe
-	[331721] = 20,      --- Spear Flurry (Mistveil Defender)
+	[331721] = 20,      -- Spear Flurry (Mistveil Defender)
 	
 	-- De Other Side
 	
 	-- Spires of Ascension
-	[320966] = 20,      -- Overhead Slash (Kin-Tara)
-	[336444] = 20,      -- Crescendo (Forsworn Helion)
+	[317943] = 20,      -- Sweeping Blow (Frostsworn Vanguard)
 	
 	-- The Necrotic Wakes
 	[324323] = 20,		-- Gruesome Cleave (Skeletal Marauder)
+
 	-- Plaguefall
 	
 	-- Theater of Pain
 	
 	-- Sanguine Depths
-	[322429] = 20,		-- Severing Slice (Chamber Sentinel)
 	
 	-- Hall of Atonement 
-	-- id ? [118459] = 20,		-- Beast Cleave (Loyal Stoneborn)
-	[346866] = 20, 		-- Stone Breathe (Loyal Stoneborn)
-	[326997] = 20,		-- Powerful Swipe (Stoneborn Slasher)
+	--[323001] = 20,      -- Glass Shards (Halkias)
+	[322936] = 20,      -- Crumbling Slam (Halkias)
+	[346866] = 20, 		-- Stone Breath (Loyal Stoneborn)
 }
 
 local Auras = {
@@ -213,9 +223,10 @@ local Auras = {
 	[321893] = true,      --- Freezing Burst (Illusionary Vulpin)
 	
 	-- De Other Side
-	[331381] = 20,		-- Slipped (Lubricator)
+	[331381] = 20,	      -- Slipped (Lubricator)
 	
 	-- Spires of Ascension
+	[324205] = 20,        -- Blinding Flash (Ventunax)
 	
 	-- The Necrotic Wakes
 	
@@ -225,7 +236,10 @@ local Auras = {
 	
 	-- Sanguine Depths
 	
-	-- Hall of Atonement 
+	-- Hall of Atonement
+
+	-- Affixes
+	[358973] = 20,        -- Wave of Terror (Season 2 Affix - Varruth)
 }
 
 local AurasNoTank = {

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -22,7 +22,6 @@ local OutputModes = {
 	["self"] = 3,
 }
 
-
 local Spells = {
 	-- Debug
 	--[] = 20,		-- ()
@@ -30,7 +29,7 @@ local Spells = {
 	--[190984] = 1,		 -- DEBUG Druid Wrath
 	--[285452] = 1,		 -- DEBUG Shaman Lava Burst
 	--[188389] = 1,		 -- DEBUG Shaman Flame Shock
-	
+
 	-- Affixes
 	[209862] = 20,		-- Volcanic Plume (Environment)
 	[226512] = 20,		-- Sanguine Ichor (Environment)
@@ -41,10 +40,11 @@ local Spells = {
 	[342494] = 20,		-- Belligerent Boast (Season 1 Prideful)
 	[356414] = 20,		-- Frost Lance (Season 2 Oros)
 	[358894] = 20,		-- Cold Snap (Season 2 Oros)
+	[358897] = 20,		-- Cold Snap (Season 2 Oros)
 	[355806] = 20,		-- Massive Smash (Season 2 Soggodon)
 	[355737] = 20,		-- Scorching Blast (Season 2 Arkolath)
 
-	
+
 	-- Mists of Tirna Scithe
 	[321968] = 20,		-- Bewildering Pollen (Tirnenn Villager)
 	[323137] = 20,		-- Bewildering Pollen (Tirnenn Villager)
@@ -57,14 +57,14 @@ local Spells = {
 	[331743] = 20,		-- Bucking Rampage (Mistveil Guardian)
 	[331748] = 20,		-- Back Kick (Mistveil Guardian)
 	[340160] = 20,		-- Radiant Breath (Mistveil Matriarch)
-	
+
 	--id ? [323177] = 20,		-- Tears of the Forest (Ingra Maloch)
 	[323250] = 20,		-- Anima Puddle (Droman Oulfarran)
 	[321834] = 20,		-- Dodge Ball (Mistcaller)
 	[336759] = 20,		-- Dodge Ball (Mistcaller)
 	[322655] = 20,		-- Acid Expulsion (Tred'ova)
 
-	
+
 	-- De Other Side
 	[334051] = 20,		-- Erupting Darkness (Death Speaker)
 	[328729] = 20,		-- Dark Lotus (Risen Cultist)
@@ -74,18 +74,23 @@ local Spells = {
 	[332672] = 20,		-- Bladestorm (Atal'ai Deathwalker)
 	[323118] = 20,		-- Blood Barrage (Hakkar the Soulflayer)
 	[331933] = 20,		-- Haywire (Defunct Dental Drill)
-	[332157] = 20,		-- Spinning Up (Headless Client)
-	[323569] = 20,		-- Spilled Essence (Environment)
+	[331398] = 20,		-- Volatile Capacitor (Volatile Memory)
+	[331008] = 20,		-- Icky Sticky (Experimental Sludge)
+	[323569] = 20,		-- Spilled Essence (Environment - Son of Hakkar boss version)
+	[332332] = 20,		-- Spilled Essence (Environment - Son of Hakkar trash version)
 	[323136] = 20,		-- Anima Starstorm (Runestag Elderhorn)
+	[345498] = 20,		-- Anima Starstorm (Runestag Elderhorn)
+	[332729] = 20,		-- Malefic Blast (Environment - Dealer's Hallway)
+
 	[323992] = 20,		-- Echo Finger Laser X-treme (Millificent Manastorm)
-			
 	[320723] = 20,		-- Displaced Blastwave (Dealer Xy'exa)
+	[320727] = 20,		-- Displaced Blastwave (Dealer Xy'exa)
 	[320232] = 20,		-- Explosive Contrivance (Dealer Xy'exa)
 	[334913] = 20,		-- Master of Death (Mueh'zala)
 	[325691] = 20,		-- Cosmic Collapse (Mueh'zala)
 	[335000] = 20,		-- Stellar Cloud (Mueh'zala)
-	
-	
+
+
 	-- Spires of Ascension
 	--[323786] = 20,		-- Swift Slice (Kyrian Dark-Praetor)
 	[323740] = 20,		-- Impact (Forsworn Squad-Leader)
@@ -93,7 +98,7 @@ local Spells = {
 	[336444] = 20,		-- Crescendo (Forsworn Helion)
 	[328466] = 20,		-- Charged Spear (Lakesis / Klotos)
 	[336420] = 20,		-- Diminuendo (Klotos / Lakesis)
-	
+
 	[331251] = 20,		-- Deep Connection (Azules / Kin-Tara)
 	[317626] = 20,		-- Maw-Touched Venom (Azules)
 	-- [321034] = 20,		-- Charged Spear (Kin-Tara) Cannot be avoided
@@ -102,8 +107,8 @@ local Spells = {
 	[324141] = 20,		-- Dark Bolt (Ventunax)
 	[323943] = 20,		-- Run Through (Devos)
 	-- [] = 20,		-- Seed of the Abyss (Devos) ???
-	
-	
+
+
 	-- The Necrotic Wake
 	[324391] = 20,		-- Frigid Spikes (Skeletal Monstrosity)
 	[324381] = 20,		-- Chill Scythe / Reaping Winds (Skeletal Monstrosity)
@@ -114,7 +119,7 @@ local Spells = {
 	[333477] = 20,		-- Gut Slice (Goregrind)
 	[345625] = 20,		-- Death Burst (Nar'zudah)
 	[327240] = 20,		-- Spine Crush (Loyal Creation)
-	
+
 	-- id ?[320637] = 20,		-- Fetid Gas (Blightbone)
 	[319897] = 20,		-- Land of the Dead (Amarth - summons Crossbowman)
 	[319902] = 20,		-- Land of the Dead (Amarth - summons Warrior)
@@ -129,8 +134,8 @@ local Spells = {
 	[328212] = 20,		-- Razorshard Ice (Nalthor the Rimebinder)
 	[320784] = 20,		-- Comet Storm (Nalthor the Rimebinder)
 	[321956] = 20,		-- Comet Storm (Nalthor the Rimebinder) (this one is for Dark Exiled players)
-	
-	
+
+
 	-- Plaguefall
 	[320072] = 20,		-- Toxic Pool (Decaying Flesh Giant)
 	-- id ?[335882] = 20,		-- Clinging Infestation (Fen Hatchling)
@@ -149,7 +154,7 @@ local Spells = {
 	[329217] = 20,		-- Slime Lunge (Doctor Ickus)
 	[322475] = 20,		-- Plague Crash (Environment Margrave Stradama)
 
-	
+
 	-- Theater of Pain
 	[337037] = 20,		-- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
 	[336996] = 20,		-- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
@@ -163,7 +168,7 @@ local Spells = {
 	[330614] = 20,		-- Vile Eruption (Rancid Gasbag) ?? TODO: Which one is correct?
 	[321039] = 20,		-- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
 	[321041] = 20,		-- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
-	
+
 	[317231] = 20,		-- Crushing Slam (Xav the Unfallen)
 	[339415] = 20,		-- Deafening Crash (Xav the Unfallen)
 	[320729] = 20,		-- Massive Cleave (Xav the Unfallen)
@@ -176,7 +181,7 @@ local Spells = {
 	[323831] = 20,		-- Death Grasp (Mordretha)
 	[339751] = 20,		-- Ghostly Charge (Mordretha)
 
-	
+
 	-- Sanguine Depths
 	[334563] = 20,		-- Volatile Trap (Dreadful Huntmaster)
 	[320991] = 20,		-- Echoing Thrust (Regal Mistdancer)
@@ -191,7 +196,7 @@ local Spells = {
 	[325885] = 20,		-- Anguished Cries (Z'rali)
 	[323810] = 20,		-- Piercing Blur (General Kaal)
 
-	
+
 	-- Halls of Atonement 
 	[325523] = 20,		-- Deadly Thrust (Depraved Darkblade)
 	[325799] = 20,		-- Rapid Fire (Depraved Houndmaster)
@@ -214,6 +219,7 @@ local SpellsNoTank = {
 	[331721] = 20,		-- Spear Flurry (Mistveil Defender)
 	
 	-- De Other Side
+	[332157] = 20,		-- Spinning Up (Headless Client)
 	
 	-- Spires of Ascension
 	[317943] = 20,		-- Sweeping Blow (Frostsworn Vanguard)
@@ -326,7 +332,7 @@ function generateMaybeOutput(user)
 					print("<EH> Error: Could not find spells"..spellNames.."in Spells or SpellsNoTank but got Timer for them. wtf")
 				end
 				local userMaxHealth = UnitHealthMax(user)
-				local msgAmount = round(amount / 1000,1)
+				local msgAmount = round(amount / 1000, 1)
 				local pct = Round(amount / userMaxHealth * 100)
 				if pct >= ElitismHelperDB.Threshold and pct >= minPct and ElitismHelperDB.Loud then
 					if _i > 0 then
@@ -357,7 +363,7 @@ function generateMaybeMeleeOutput(user)
 				local name = obj.name
 				local amount = obj.amount
 				local userMaxHealth = UnitHealthMax(user)
-				local msgAmount = round(amount / 1000,1)
+				local msgAmount = round(amount / 1000, 1)
 				local pct = Round(amount / userMaxHealth * 100)
 				if pct > MeleeHitters[srcID] and pct > ElitismHelperDB.Threshold and ElitismHelperDB.Loud then
 					msg = msg..name.." for "..msgAmount.."k ("..pct.."%)"
@@ -642,7 +648,7 @@ function ElitismFrame:CHALLENGE_MODE_COMPLETED(event,...)
 		for k, v in pairs(CombinedFails) do table.insert(u, { key = k, value = v }) end
 		table.sort(u, compareDamage)
 		for k,v in pairs(u) do
-				maybeSendChatMessage(k..". "..v["key"].." "..round(v["value"] / 1000,1).."k")
+				maybeSendChatMessage(k..". "..v["key"].." "..round(v["value"] / 1000, 1).."k")
 		end
 	end
 end
@@ -791,21 +797,21 @@ function ElitismFrame:COMBAT_LOG_EVENT_UNFILTERED(event,...)
 	local timestamp, eventType, hideCaster, srcGUID, srcName, srcFlags, srcFlags2, dstGUID, dstName, dstFlags, dstFlags2 = CombatLogGetCurrentEventInfo(); -- Those arguments appear for all combat event variants.
 	local eventPrefix, eventSuffix = eventType:match("^(.-)_?([^_]*)$");
 	if (eventPrefix:match("^SPELL") or eventPrefix:match("^RANGE")) and eventSuffix == "DAMAGE" then
-		local spellId, spellName, spellSchool, sAmount, aOverkill, sSchool, sResisted, sBlocked, sAbsorbed, sCritical, sGlancing, sCrushing, sOffhand, _ = select(12,CombatLogGetCurrentEventInfo())
+		local spellId, spellName, spellSchool, sAmount, aOverkill, sSchool, sResisted, sBlocked, sAbsorbed, sCritical, sGlancing, sCrushing, sOffhand, _ = select(12, CombatLogGetCurrentEventInfo())
 		ElitismFrame:SpellDamage(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, sAmount)
 	elseif eventPrefix:match("^SWING") and eventSuffix == "DAMAGE" then
-		local aAmount, aOverkill, aSchool, aResisted, aBlocked, aAbsorbed, aCritical, aGlancing, aCrushing, aOffhand, _ = select(12,CombatLogGetCurrentEventInfo())
+		local aAmount, aOverkill, aSchool, aResisted, aBlocked, aAbsorbed, aCritical, aGlancing, aCrushing, aOffhand, _ = select(12, CombatLogGetCurrentEventInfo())
 		ElitismFrame:SwingDamage(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, aAmount)
 	elseif eventPrefix:match("^SPELL") and eventSuffix == "MISSED" then
-		local spellId, spellName, spellSchool, missType, isOffHand, mAmount = select(12,CombatLogGetCurrentEventInfo())
+		local spellId, spellName, spellSchool, missType, isOffHand, mAmount = select(12, CombatLogGetCurrentEventInfo())
 		if mAmount then
 			ElitismFrame:SpellDamage(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, mAmount)
 		end
 	elseif eventType == "SPELL_AURA_APPLIED" then
-		local spellId, spellName, spellSchool, auraType = select(12,CombatLogGetCurrentEventInfo())
+		local spellId, spellName, spellSchool, auraType = select(12, CombatLogGetCurrentEventInfo())
 		ElitismFrame:AuraApply(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, auraType)
 	elseif eventType == "SPELL_AURA_APPLIED_DOSE" then
-		local spellId, spellName, spellSchool, auraType, auraAmount = select(12,CombatLogGetCurrentEventInfo())
+		local spellId, spellName, spellSchool, auraType, auraAmount = select(12, CombatLogGetCurrentEventInfo())
 		ElitismFrame:AuraApply(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, auraType, auraAmount)
 	end
 end

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -239,7 +239,7 @@ local Auras = {
 	[324205] = 20,        -- Blinding Flash (Ventunax)
 	
 	-- The Necrotic Wake
-    [324293] = 20         -- Rasping Scream (Skeletal Marauder)
+    [324293] = 20,        -- Rasping Scream (Skeletal Marauder)
 	
 	-- Plaguefall
 	

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -7,7 +7,7 @@ local CombinedFails = {}
 local FailByAbility = {}
 local activeUser = nil
 local AddonVersion = 0.2
-local playerUser = GetUnitName("player",true).."-"..GetRealmName():gsub(" ", "")
+local playerUser = GetUnitName("player", true).."-"..GetRealmName():gsub(" ", "")
 local defaultElitismHelperDBValues = {
 	Loud = true,
 	Threshold = 30,
@@ -16,7 +16,7 @@ local defaultElitismHelperDBValues = {
 }
 
 local OutputModes = {
-    ["default"] = 0,
+	["default"] = 0,
 	["party"] = 1,
 	["yell"] = 2,
 	["self"] = 3,
@@ -25,43 +25,45 @@ local OutputModes = {
 
 local Spells = {
 	-- Debug
-	--[] = 20,      --  ()
+	--[] = 20,		-- ()
 	--[252144] = 1,
-	--[190984] = 1,       -- DEBUG Druid Wrath
-	--[285452] = 1,       -- DEBUG Shaman Lava Burst
-	--[188389] = 1,       -- DEBUG Shaman Flame Shock
+	--[190984] = 1,		 -- DEBUG Druid Wrath
+	--[285452] = 1,		 -- DEBUG Shaman Lava Burst
+	--[188389] = 1,		 -- DEBUG Shaman Flame Shock
 	
 	-- Affixes
 	[209862] = 20,		-- Volcanic Plume (Environment)
 	[226512] = 20,		-- Sanguine Ichor (Environment)
-	[240448] = 20,      -- Quaking (Environment)
-	[343520] = 20,      -- Storming (Environment)
-	[350163] = 20, 		-- Melee (Spiteful Shade)
+	[240448] = 20,		-- Quaking (Environment)
+	[343520] = 20,		-- Storming (Environment)
+	[350163] = 20,		-- Melee (Spiteful Shade)
 
-	[342494] = 20, 		-- Belligerent Boast (Season 1 Prideful)
-	[356414] = 20, 		-- Frost Lance (Season 2 Oros)
-	[358894] = 20, 		-- Cold Snap (Season 2 Oros)
-	[355806] = 20, 		-- Massive Smash (Season 2 Soggodon)
-	[355737] = 20, 		-- Scorching Blast (Season 2 Arkolath)
+	[342494] = 20,		-- Belligerent Boast (Season 1 Prideful)
+	[356414] = 20,		-- Frost Lance (Season 2 Oros)
+	[358894] = 20,		-- Cold Snap (Season 2 Oros)
+	[355806] = 20,		-- Massive Smash (Season 2 Soggodon)
+	[355737] = 20,		-- Scorching Blast (Season 2 Arkolath)
+
 	
 	-- Mists of Tirna Scithe
-	[321968] = 20, 		-- Bewildering Pollen (tirnenn Villager)
-	[323137] = 20, 		-- Bewildering Pollen (tirnenn Villager)
-	[323250] = 20,      -- Anima Puddle (Droman Oulfarran)
-	[325027] = 20,      -- Bramble Burst (Drust Boughbreaker)
-	[326022] = 20,      -- Acid Globule (Spinemaw Gorger)
+	[321968] = 20,		-- Bewildering Pollen (Tirnenn Villager)
+	[323137] = 20,		-- Bewildering Pollen (Tirnenn Villager)
+	[323250] = 20,		-- Anima Puddle (Droman Oulfarran)
+	[325027] = 20,		-- Bramble Burst (Drust Boughbreaker)
+	[326022] = 20,		-- Acid Globule (Spinemaw Gorger)
 	[340300] = 20,		-- Tongue Lashing (Mistveil Gorgegullet)
 	[340304] = 20,		-- Poisonous Secretions (Mistveil Gorgegullet)
-	[340311] = 20,      -- Crushing Leap (Mistveil Gorgegullet)
+	[340311] = 20,		-- Crushing Leap (Mistveil Gorgegullet)
 	[331743] = 20,		-- Bucking Rampage (Mistveil Guardian)
-	[331748] = 20,      -- Back Kick (Mistveil Guardian)
+	[331748] = 20,		-- Back Kick (Mistveil Guardian)
 	[340160] = 20,		-- Radiant Breath (Mistveil Matriarch)
 	
-	--id ? [323177] = 20,		-- Tears of the Forest(Ingra Maloch)
-	[323250] = 20,      -- Anima Puddle (Droman Oulfarran)
-	[321834] = 20,      -- Dodge Ball (Mistcaller)
-	[336759] = 20,      -- Dodge Ball (Mistcaller)
-	[322655] = 20,		-- Acid Expulsion (Tred'Ova)
+	--id ? [323177] = 20,		-- Tears of the Forest (Ingra Maloch)
+	[323250] = 20,		-- Anima Puddle (Droman Oulfarran)
+	[321834] = 20,		-- Dodge Ball (Mistcaller)
+	[336759] = 20,		-- Dodge Ball (Mistcaller)
+	[322655] = 20,		-- Acid Expulsion (Tred'ova)
+
 	
 	-- De Other Side
 	[334051] = 20,		-- Erupting Darkness (Death Speaker)
@@ -69,121 +71,126 @@ local Spells = {
 	[333250] = 20,		-- Reaver (Risen Warlord)
 	[342869] = 20,		-- Enraged Mask (Enraged Spirit)
 	[333790] = 20,		-- Enraged Mask (Enraged Spirit)
-	[332672] = 20,      -- Bladestorm (Atal'ai Deathwalker)
-	[323118] = 20,      -- Blood Barrage (Hakkar the Soulflayer)
+	[332672] = 20,		-- Bladestorm (Atal'ai Deathwalker)
+	[323118] = 20,		-- Blood Barrage (Hakkar the Soulflayer)
 	[331933] = 20,		-- Haywire (Defunct Dental Drill)
-	[332157] = 20,      -- Spinning Up (Headless Client)
-	[323569] = 20,   	-- Spilled Essence (Environment)
-	[323136] = 20,      -- Anima Starstorm (Runestag Elderhorn)
-	[323992] = 20,      -- Echo Finger Laser X-treme (Millificent Manastorm)
+	[332157] = 20,		-- Spinning Up (Headless Client)
+	[323569] = 20,		-- Spilled Essence (Environment)
+	[323136] = 20,		-- Anima Starstorm (Runestag Elderhorn)
+	[323992] = 20,		-- Echo Finger Laser X-treme (Millificent Manastorm)
 			
 	[320723] = 20,		-- Displaced Blastwave (Dealer Xy'exa)
-	[320232] = 20,      -- Explosive Contrivance (Dealer Xy'exa)
+	[320232] = 20,		-- Explosive Contrivance (Dealer Xy'exa)
 	[334913] = 20,		-- Master of Death (Mueh'zala)
-	[325691] = 20,      -- Cosmic Collapse (Mueh'zala)
+	[325691] = 20,		-- Cosmic Collapse (Mueh'zala)
 	[335000] = 20,		-- Stellar Cloud (Mueh'zala)
 	
 	
 	-- Spires of Ascension
-	--[323786] = 20,      -- Swift Slice (Kyrian Dark-Praetor)
+	--[323786] = 20,		-- Swift Slice (Kyrian Dark-Praetor)
 	[323740] = 20,		-- Impact (Forsworn Squad-Leader)
 	[336447] = 20,		-- Crashing Strike (Forsworn Squad-Leader)
 	[336444] = 20,		-- Crescendo (Forsworn Helion)
 	[328466] = 20,		-- Charged Spear (Lakesis / Klotos)
 	[336420] = 20,		-- Diminuendo (Klotos / Lakesis)
 	
-	[331251] = 20,      -- Deep Connection (Azules / Kin-Tara)
-	[317626] = 20,      -- Maw-Touched Venom (Azules)
-	-- [321034] = 20,      -- Charged Spear (Kin-Tara) Cannot be avoided
-	[324662] = 20,      -- Ionized Plasma (Multiple) Can this be avoided?
+	[331251] = 20,		-- Deep Connection (Azules / Kin-Tara)
+	[317626] = 20,		-- Maw-Touched Venom (Azules)
+	-- [321034] = 20,		-- Charged Spear (Kin-Tara) Cannot be avoided
+	[324662] = 20,		-- Ionized Plasma (Multiple) Can this be avoided?
 	[324370] = 20,		-- Attenuated Barrage (Kin-Tara)
-	[324141] = 20,      -- Dark Bolt (Ventunax)
-	[323943] = 20,      -- Run Through (Devos)
+	[324141] = 20,		-- Dark Bolt (Ventunax)
+	[323943] = 20,		-- Run Through (Devos)
 	-- [] = 20,		-- Seed of the Abyss (Devos) ???
 	
 	
 	-- The Necrotic Wake
 	[324391] = 20,		-- Frigid Spikes (Skeletal Monstrosity)
 	[324381] = 20,		-- Chill Scythe / Reaping Winds (Skeletal Monstrosity)
-	[323957] = 20,      -- Animate Dead (Zolramus Necromancer - summons Warrior)
-	[324026] = 20,      -- Animate Dead (Zolramus Necromancer - summons Crossbowman)
-	[324027] = 20,      -- Animate Dead (Zolramus Necromancer - summons Mage)
+	[323957] = 20,		-- Animate Dead (Zolramus Necromancer - summons Warrior)
+	[324026] = 20,		-- Animate Dead (Zolramus Necromancer - summons Crossbowman)
+	[324027] = 20,		-- Animate Dead (Zolramus Necromancer - summons Mage)
 	[320574] = 20,		-- Shadow Well (Zolramus Sorcerer)
 	[333477] = 20,		-- Gut Slice (Goregrind)
-	[345625] = 20,      -- Death Burst (Nar'zudah)
-	[327240] = 20,      -- Spine Crush (Loyal Creation)
+	[345625] = 20,		-- Death Burst (Nar'zudah)
+	[327240] = 20,		-- Spine Crush (Loyal Creation)
 	
-	-- id ?[320637] = 20, 		-- Fetid Gas (Blightbone)
-	[319897] = 20,      -- Land of the Dead (Amarth - summons Crossbowman)
-	[319902] = 20,      -- Land of the Dead (Amarth - summons Warrior)
-	[333627] = 20,      -- Land of the Dead (Amarth - summons Mage)
+	-- id ?[320637] = 20,		-- Fetid Gas (Blightbone)
+	[319897] = 20,		-- Land of the Dead (Amarth - summons Crossbowman)
+	[319902] = 20,		-- Land of the Dead (Amarth - summons Warrior)
+	[333627] = 20,		-- Land of the Dead (Amarth - summons Mage)
 	[321253] = 20,		-- Final Harvest (Amarth)
 	[333489] = 20,		-- Necrotic Breath (Amarth)
 	[333492] = 20,		-- Necrotic Ichor (Amarth apply by Necrotic Breath)
 	[320365] = 20,		-- Embalming Ichor (Surgeon Stitchflesh)
 	[320366] = 20,		-- Embalming Ichor (Surgeon Stitchflesh)
 	[327952] = 20,		-- Meat Hook (Stitchflesh)
-	[327100] = 20,      -- Noxious Fog (Stitchflesh)
-	[328212] = 20,      -- Razorshard Ice (Nalthor the Rimebinder)
+	[327100] = 20,		-- Noxious Fog (Stitchflesh)
+	[328212] = 20,		-- Razorshard Ice (Nalthor the Rimebinder)
 	[320784] = 20,		-- Comet Storm (Nalthor the Rimebinder)
-	[321956] = 20,      -- Comet Storm (Nalthor the Rimebinder) (this one is for Dark Exiled players)
+	[321956] = 20,		-- Comet Storm (Nalthor the Rimebinder) (this one is for Dark Exiled players)
+	
 	
 	-- Plaguefall
-	[320072] = 20, 		-- Toxic Pool (Decaying Flesh Giant)
-	-- id ?[335882] = 20, 		-- Clinging Infestation (Fen Hatchling)
+	[320072] = 20,		-- Toxic Pool (Decaying Flesh Giant)
+	-- id ?[335882] = 20,		-- Clinging Infestation (Fen Hatchling)
 	[330404] = 20,		-- Wing Buffet (Plagueroc)
 	-- id ?[320040] = 20,		-- Plagued Carrion (Decaying Flesh Giant)
 	[320072] = 20,		-- Toxic pool (Decaying Flesh Giant)
-	[318949] = 20,      -- Festering Belch (Blighted Spinebreaker)
-	-- id ?[320576] = 20,      -- Obliterating Ooze (Virulax Blightweaver)
-	[319120] = 20, 		-- Putrid Bile (Gushing Slime)
-	[327233] = 20, 		-- Belch Plague (Plagebelcher)
-	[320519] = 20, 		-- Jagged Spines (Blighted Spinebreaker)
+	[318949] = 20,		-- Festering Belch (Blighted Spinebreaker)
+	-- id ?[320576] = 20,		-- Obliterating Ooze (Virulax Blightweaver)
+	[319120] = 20,		-- Putrid Bile (Gushing Slime)
+	[327233] = 20,		-- Belch Plague (Plagebelcher)
+	[320519] = 20,		-- Jagged Spines (Blighted Spinebreaker)
 	[328501] = 20,		-- Plagued Bomb (Environment)
 	[324667] = 20,		-- Slime Wave (Globgrog)
 	[626242] = 20,		-- Slime Wave (Globgrog)
 	[333808] = 20,		-- Oozing Outbreak (Doctor Ickus)
 	[329217] = 20,		-- Slime Lunge (Doctor Ickus)
 	[322475] = 20,		-- Plague Crash (Environment Margrave Stradama)
+
 	
 	-- Theater of Pain
 	[337037] = 20,		-- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
-	[336996] = 20,      -- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
-	[317605] = 20,      -- Whirlwind (Nekthara the Mangler and Rek the Hardened)
+	[336996] = 20,		-- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
+	[317605] = 20,		-- Whirlwind (Nekthara the Mangler and Rek the Hardened)
 	[332708] = 20,		-- Ground Smash (Heavin the Breaker)
 	[334025] = 20,		-- Bloodthirsty Charge (Haruga the Bloodthirsty)
-	[333297] = 20, 		-- Death Winds (Nefarious Darkspeaker)
+	[333297] = 20,		-- Death Winds (Nefarious Darkspeaker)
 	[331243] = 20,		-- Bone Spikes (Soulforged Bonereaver)
 	[331224] = 20,		-- Bonestorm (Soulforged Bonereaver)
 	[330608] = 20,		-- Vile Eruption (Rancid Gasbag) ?? TODO: Which one is correct?
-	[330614] = 20,      -- Vile Eruption (Rancid Gasbag) ?? TODO: Which one is correct?
-	[321039] = 20,      -- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
-	[321041] = 20,      -- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
+	[330614] = 20,		-- Vile Eruption (Rancid Gasbag) ?? TODO: Which one is correct?
+	[321039] = 20,		-- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
+	[321041] = 20,		-- Disgusting Burst (Disgusting Refuse and Blighted Sludge-Spewer)
 	
-	[317231] = 20, 		-- Crushing Slam (Xav the Unfallen)
+	[317231] = 20,		-- Crushing Slam (Xav the Unfallen)
 	[339415] = 20,		-- Deafening Crash (Xav the Unfallen)
 	[320729] = 20,		-- Massive Cleave (Xav the Unfallen)
 	[318406] = 20,		-- Tenderizing Smash (Gorechop)
-	[323406] = 20,      -- Jagged Gash (Gorechop)
+	[323406] = 20,		-- Jagged Gash (Gorechop)
 	-- id ?[323542] = 20,		-- Oozing (Gorechop)
-	[317367] = 20,      -- Necrotic Volley (Kul'tharok)
+	[317367] = 20,		-- Necrotic Volley (Kul'tharok)
 	[323681] = 20,		-- Dark Devastation (Mordretha)
 	[339550] = 20,		-- Echo of Battle (Mordretha)
 	[323831] = 20,		-- Death Grasp (Mordretha)
 	[339751] = 20,		-- Ghostly Charge (Mordretha)
+
 	
 	-- Sanguine Depths
 	[334563] = 20,		-- Volatile Trap (Dreadful Huntmaster)
 	[320991] = 20,		-- Echoing Thrust (Regal Mistdancer)
 	[320999] = 20,		-- Echoing Thrust (Regal Mistdancer Mirror)
 	[322418] = 20,		-- Craggy Fracture (Chamber Sentinel)
-	[334378] = 20,      -- Explosive Vellum (Research Scribe)
-	[323573] = 20,      -- Residue (Fleeting Manifestation)
-	[325885] = 20,      -- Anguished Cries (Z'rali)
+	[334378] = 20,		-- Explosive Vellum (Research Scribe)
+	[323573] = 20,		-- Residue (Fleeting Manifestation)
 	[334615] = 20,		-- Sweeping Slash (Head Custodian Javlin)
 	[322212] = 20,		-- Growing Mistrust (Vestige of Doubt)
-	[328494] = 20, 		-- Sintouched Anima (Environment)
+	[328494] = 20,		-- Sintouched Anima (Environment)
+
+	[325885] = 20,		-- Anguished Cries (Z'rali)
 	[323810] = 20,		-- Piercing Blur (General Kaal)
+
 	
 	-- Halls of Atonement 
 	[325523] = 20,		-- Deadly Thrust (Depraved Darkblade)
@@ -195,26 +202,26 @@ local Spells = {
 	[322945] = 20,		-- Heave Debris (Halkias)
 	[324044] = 20,		-- Refracted Sinlight (Halkias)
 	[319702] = 20,		-- Blood Torrent (Echelon)
-	[329340] = 20, 		-- Anima Fountain (High Adjudicator Aleez)
-	[338013] = 20, 		-- Anima Fountain (High Adjudicator Aleez)
-	[323126] = 20, 		-- Telekinetic Collision (Lord Chamberlain)
-    [329113] = 20,		-- Telekinteic Onslaught (Lord Chamberlain)
+	[329340] = 20,		-- Anima Fountain (High Adjudicator Aleez)
+	[338013] = 20,		-- Anima Fountain (High Adjudicator Aleez)
+	[323126] = 20,		-- Telekinetic Collision (Lord Chamberlain)
+	[329113] = 20,		-- Telekinteic Onslaught (Lord Chamberlain)
 	[327885] = 20,		-- Erupting Torment (Lord Chamberlain)
 }
 
 local SpellsNoTank = {
-    -- Mists of Tirna Scithe
-	[331721] = 20,      -- Spear Flurry (Mistveil Defender)
+	-- Mists of Tirna Scithe
+	[331721] = 20,		-- Spear Flurry (Mistveil Defender)
 	
 	-- De Other Side
 	
 	-- Spires of Ascension
-	[317943] = 20,      -- Sweeping Blow (Frostsworn Vanguard)
-    [324608] = 20,      -- Charged Stomp (Oryphrion)
+	[317943] = 20,		-- Sweeping Blow (Frostsworn Vanguard)
+	[324608] = 20,		-- Charged Stomp (Oryphrion)
 	
 	-- The Necrotic Wake
 	[324323] = 20,		-- Gruesome Cleave (Skeletal Marauder)
-    [323489] = 20,      -- Throw Cleaver (Flesh Crafter, Stitching Assistant)
+	[323489] = 20,		-- Throw Cleaver (Flesh Crafter, Stitching Assistant)
 
 	-- Plaguefall
 	
@@ -223,24 +230,24 @@ local SpellsNoTank = {
 	-- Sanguine Depths
 	
 	-- Halls of Atonement 
-	--[323001] = 20,      -- Glass Shards (Halkias) This is always unavoidable for tanks but sometimes unavoidable for everyone
-	[322936] = 20,      -- Crumbling Slam (Halkias)
-	[346866] = 20, 		-- Stone Breath (Loyal Stoneborn)
+	--[323001] = 20,		-- Glass Shards (Halkias) This is always unavoidable for tanks but sometimes unavoidable for everyone
+	[322936] = 20,		-- Crumbling Slam (Halkias)
+	[346866] = 20,		-- Stone Breath (Loyal Stoneborn)
 }
 
 local Auras = {
-    -- Mists of Tirna Scithe
-    [323137] = true,      --- Bewildering Pollen (Drohman Oulfarran)
-	[321893] = true,      --- Freezing Burst (Illusionary Vulpin)
+	-- Mists of Tirna Scithe
+	[323137] = true,	--- Bewildering Pollen (Drohman Oulfarran)
+	[321893] = true,	--- Freezing Burst (Illusionary Vulpin)
 	
 	-- De Other Side
-	[331381] = 20,	      -- Slipped (Lubricator)
+	[331381] = 20,		-- Slipped (Lubricator)
 	
 	-- Spires of Ascension
-	[324205] = 20,        -- Blinding Flash (Ventunax)
+	[324205] = 20,		-- Blinding Flash (Ventunax)
 	
 	-- The Necrotic Wake
-    [324293] = 20,        -- Rasping Scream (Skeletal Marauder)
+	[324293] = 20,		-- Rasping Scream (Skeletal Marauder)
 	
 	-- Plaguefall
 	
@@ -251,7 +258,7 @@ local Auras = {
 	-- Halls of Atonement
 
 	-- Affixes
-	[358973] = 20,        -- Wave of Terror (Season 2 Affix - Varruth)
+	[358973] = 20,		-- Wave of Terror (Season 2 Affix - Varruth)
 }
 
 local AurasNoTank = {
@@ -263,7 +270,7 @@ local MeleeHitters = {
 }
 
 function round(number, decimals)
-    return (("%%.%df"):format(decimals)):format(number)
+	return (("%%.%df"):format(decimals)):format(number)
 end
 
 local ElitismFrame = CreateFrame("Frame", "ElitismFrame")
@@ -286,7 +293,7 @@ ElitismFrame.text:SetTextHeight(13)
 ElitismFrame:SetAlpha(1)
 
 function table.pack(...)
-  return { n = select("#", ...), ... }
+	return { n = select("#", ...), ... }
 end
 
 ElitismFrame:SetScript("OnEvent", function(self, event_name, ...)
@@ -507,7 +514,7 @@ SlashCmdList["ELITISMHELPER"] = function(msg,editBox)
 				for player,fails in pairs(FailByAbility) do
 					print("Hits for "..player)
 					for k,v in pairs(fails) do
-						print("  " .. v.cnt .. "x" .. GetSpellLink(k) .. " = " .. round(v.sum / 1000, 1) .. "k")
+						print(" " .. v.cnt .. "x" .. GetSpellLink(k) .. " = " .. round(v.sum / 1000, 1) .. "k")
 					end
 				end
 			else
@@ -647,14 +654,14 @@ function ElitismFrame:CHALLENGE_MODE_START(event,...)
 end
 
 function ElitismFrame:SplitString(inputstr, sep)
-        if sep == nil then
-                sep = "%s"
-        end
-        local t={}
-        for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
-                table.insert(t, str)
-        end
-        return t
+	if sep == nil then
+		sep = "%s"
+	end
+	local t={}
+	for str in string.gmatch(inputstr, "([^"..sep.."]+)") do
+		table.insert(t, str)
+	end
+	return t
 end
 
 
@@ -771,7 +778,7 @@ function ElitismFrame:SwingDamage(timestamp, eventType, srcGUID, srcName, srcFla
 end
 
 function ElitismFrame:AuraApply(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, auraType, auraAmount)
-	if (Auras[spellId] or (AurasNoTank[spellId] and UnitGroupRolesAssigned(dstName) ~= "TANK")) and UnitIsPlayer(dstName)  then
+	if (Auras[spellId] or (AurasNoTank[spellId] and UnitGroupRolesAssigned(dstName) ~= "TANK")) and UnitIsPlayer(dstName) then
 		if auraAmount and ElitismHelperDB.Loud then
 			maybeSendChatMessage("<EH> "..dstName.." got hit by "..GetSpellLink(spellId)..". "..auraAmount.." Stacks.")
 		elseif ElitismHelperDB.Loud then
@@ -790,7 +797,7 @@ function ElitismFrame:COMBAT_LOG_EVENT_UNFILTERED(event,...)
 		local aAmount, aOverkill, aSchool, aResisted, aBlocked, aAbsorbed, aCritical, aGlancing, aCrushing, aOffhand, _ = select(12,CombatLogGetCurrentEventInfo())
 		ElitismFrame:SwingDamage(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, aAmount)
 	elseif eventPrefix:match("^SPELL") and eventSuffix == "MISSED" then
-		local spellId, spellName, spellSchool, missType, isOffHand, mAmount  = select(12,CombatLogGetCurrentEventInfo())
+		local spellId, spellName, spellSchool, missType, isOffHand, mAmount = select(12,CombatLogGetCurrentEventInfo())
 		if mAmount then
 			ElitismFrame:SpellDamage(timestamp, eventType, srcGUID, srcName, srcFlags, dstGUID, dstName, dstFlags, spellId, spellName, spellSchool, mAmount)
 		end

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -43,6 +43,7 @@ local Spells = {
 	[358897] = 20,		-- Cold Snap (Season 2 Oros)
 	[355806] = 20,		-- Massive Smash (Season 2 Soggodon)
 	[355737] = 20,		-- Scorching Blast (Season 2 Arkolath)
+	[355738] = 20,		-- Scorching Blast DoT (Season 2 Arkolath)
 
 
 	-- Mists of Tirna Scithe
@@ -139,20 +140,25 @@ local Spells = {
 
 	-- Plaguefall
 	[320072] = 20,		-- Toxic Pool (Decaying Flesh Giant)
+	[330513] = 20,		-- Doom Shroom (Environment)
 	-- id ?[335882] = 20,		-- Clinging Infestation (Fen Hatchling)
 	[330404] = 20,		-- Wing Buffet (Plagueroc)
 	-- id ?[320040] = 20,		-- Plagued Carrion (Decaying Flesh Giant)
-	[320072] = 20,		-- Toxic pool (Decaying Flesh Giant)
+	[320072] = 20,		-- Toxic Pool (Decaying Flesh Giant)
+	[344001] = 20,		-- Slime Trail (Environment)
 	[318949] = 20,		-- Festering Belch (Blighted Spinebreaker)
-	-- id ?[320576] = 20,		-- Obliterating Ooze (Virulax Blightweaver)
+	[320576] = 20,		-- Obliterating Ooze (Virulax Blightweaver)
 	[319120] = 20,		-- Putrid Bile (Gushing Slime)
 	[327233] = 20,		-- Belch Plague (Plagebelcher)
 	[320519] = 20,		-- Jagged Spines (Blighted Spinebreaker)
-	[328501] = 20,		-- Plagued Bomb (Environment)
+	[328501] = 20,		-- Plague Bomb (Environment)
+	[328986] = 20,		-- Violent Detonation (Environment - Unstable Canister)
+
 	[324667] = 20,		-- Slime Wave (Globgrog)
-	[626242] = 20,		-- Slime Wave (Globgrog)
+	[326242] = 20,		-- Slime Wave DoT (Globgrog)
 	[333808] = 20,		-- Oozing Outbreak (Doctor Ickus)
 	[329217] = 20,		-- Slime Lunge (Doctor Ickus)
+	[330026] = 20,		-- Slime Lunge (Doctor Ickus)
 	[322475] = 20,		-- Plague Crash (Environment Margrave Stradama)
 
 
@@ -258,6 +264,7 @@ local Auras = {
 	[324293] = 20,		-- Rasping Scream (Skeletal Marauder)
 	
 	-- Plaguefall
+	[330092] = 20,		-- Plaguefallen (Environment)
 	
 	-- Theater of Pain
 	

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -80,6 +80,7 @@ local Spells = {
 	[332332] = 20,		-- Spilled Essence (Environment - Son of Hakkar trash version)
 	[323136] = 20,		-- Anima Starstorm (Runestag Elderhorn)
 	[345498] = 20,		-- Anima Starstorm (Runestag Elderhorn)
+	[340026] = 20,		-- Wailing Grief (Mythresh, Sky's Talons)
 	[332729] = 20,		-- Malefic Blast (Environment - Dealer's Hallway)
 
 	[323992] = 20,		-- Echo Finger Laser X-treme (Millificent Manastorm)
@@ -248,6 +249,7 @@ local Auras = {
 	
 	-- De Other Side
 	[331381] = 20,		-- Slipped (Lubricator)
+	[334505] = 20,		-- Shimmerdust Sleep (Weald Shimmermoth)
 	
 	-- Spires of Ascension
 	[324205] = 20,		-- Blinding Flash (Ventunax)

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -63,7 +63,10 @@ local Spells = {
 	[323250] = 20,		-- Anima Puddle (Droman Oulfarran)
 	[321834] = 20,		-- Dodge Ball (Mistcaller)
 	[336759] = 20,		-- Dodge Ball (Mistcaller)
+	[321893] = 20,		-- Freezing Burst (Mistcaller)
 	[322655] = 20,		-- Acid Expulsion (Tred'ova)
+	[326309] = 20,		-- Decomposing Acid (Tred'ova)
+	[326263] = 20,		-- Anima Shedding (Tred'ova)
 
 
 	-- De Other Side
@@ -201,8 +204,8 @@ local Spells = {
 	[323573] = 20,		-- Residue (Fleeting Manifestation)
 	[334615] = 20,		-- Sweeping Slash (Head Custodian Javlin)
 	[322212] = 20,		-- Growing Mistrust (Vestige of Doubt)
-	[328494] = 20,		-- Sintouched Anima (Environment)
 
+	[328494] = 20,		-- Sintouched Anima (Executor Tarvold)
 	[325885] = 20,		-- Anguished Cries (Z'rali)
 	[323810] = 20,		-- Piercing Blur (General Kaal)
 
@@ -255,8 +258,6 @@ local SpellsNoTank = {
 
 local Auras = {
 	-- Mists of Tirna Scithe
-	[323137] = true,	--- Bewildering Pollen (Drohman Oulfarran)
-	[321893] = true,	--- Freezing Burst (Illusionary Vulpin)
 	
 	-- De Other Side
 	[331381] = 20,		-- Slipped (Lubricator)

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -140,7 +140,8 @@ local Spells = {
 
 	-- Plaguefall
 	[320072] = 20,		-- Toxic Pool (Decaying Flesh Giant)
-	[330513] = 20,		-- Doom Shroom (Environment)
+	[330513] = 20,		-- Doom Shroom DoT (Environment)
+	[327552] = 20,		-- Doom Shroom (Environment)
 	-- id ?[335882] = 20,		-- Clinging Infestation (Fen Hatchling)
 	[330404] = 20,		-- Wing Buffet (Plagueroc)
 	-- id ?[320040] = 20,		-- Plagued Carrion (Decaying Flesh Giant)
@@ -153,6 +154,7 @@ local Spells = {
 	[320519] = 20,		-- Jagged Spines (Blighted Spinebreaker)
 	[328501] = 20,		-- Plague Bomb (Environment)
 	[328986] = 20,		-- Violent Detonation (Environment - Unstable Canister)
+	[330135] = 20,		-- Fount of Pestilence (Environment - Stradama's Slime)
 
 	[324667] = 20,		-- Slime Wave (Globgrog)
 	[326242] = 20,		-- Slime Wave DoT (Globgrog)
@@ -168,6 +170,7 @@ local Spells = {
 	[317605] = 20,		-- Whirlwind (Nekthara the Mangler and Rek the Hardened)
 	[332708] = 20,		-- Ground Smash (Heavin the Breaker)
 	[334025] = 20,		-- Bloodthirsty Charge (Haruga the Bloodthirsty)
+	[333301] = 20,		-- Curse of Desolation (Nefarious Darkspeaker)
 	[333297] = 20,		-- Death Winds (Nefarious Darkspeaker)
 	[331243] = 20,		-- Bone Spikes (Soulforged Bonereaver)
 	[331224] = 20,		-- Bonestorm (Soulforged Bonereaver)
@@ -265,6 +268,7 @@ local Auras = {
 	
 	-- Plaguefall
 	[330092] = 20,		-- Plaguefallen (Environment)
+	[336301] = 20,		-- Web Wrap (Domina Venomblade)
 	
 	-- Theater of Pain
 	

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -217,11 +217,13 @@ local Spells = {
 	[322945] = 20,		-- Heave Debris (Halkias)
 	[324044] = 20,		-- Refracted Sinlight (Halkias)
 	[319702] = 20,		-- Blood Torrent (Echelon)
+	[319703] = 20,		-- Blood Torrent (Echelon)
 	[329340] = 20,		-- Anima Fountain (High Adjudicator Aleez)
 	[338013] = 20,		-- Anima Fountain (High Adjudicator Aleez)
 	[323126] = 20,		-- Telekinetic Collision (Lord Chamberlain)
 	[329113] = 20,		-- Telekinteic Onslaught (Lord Chamberlain)
 	[327885] = 20,		-- Erupting Torment (Lord Chamberlain)
+	[323236] = 20,		-- Unleashed Suffering (Lord Chamberlain)
 }
 
 local SpellsNoTank = {

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -44,7 +44,7 @@ local Spells = {
 	[355806] = 20, 		-- Massive Smash (Season 2 Soggodon)
 	[355737] = 20, 		-- Scorching Blast (Season 2 Arkolath)
 	
-	-- Mists of Tirna Scythe
+	-- Mists of Tirna Scithe
 	[321968] = 20, 		-- Bewildering Pollen (tirnenn Villager)
 	[323137] = 20, 		-- Bewildering Pollen (tirnenn Villager)
 	[323250] = 20,      -- Anima Puddle (Droman Oulfarran)
@@ -108,11 +108,19 @@ local Spells = {
 	-- The Necrotic Wake
 	[324391] = 20,		-- Frigid Spikes (Skeletal Monstrosity)
 	[324381] = 20,		-- Chill Scythe / Reaping Winds (Skeletal Monstrosity)
+	[323957] = 20,      -- Animate Dead (Zolramus Necromancer - summons Warrior)
+	[324026] = 20,      -- Animate Dead (Zolramus Necromancer - summons Crossbowman)
+	[324027] = 20,      -- Animate Dead (Zolramus Necromancer - summons Mage)
 	[320574] = 20,		-- Shadow Well (Zolramus Sorcerer)
 	[333477] = 20,		-- Gut Slice (Goregrind)
-    [345625] = 20,      -- Death Burst (Nar'zudah)
+	[345625] = 20,      -- Death Burst (Nar'zudah)
+	[327240] = 20,      -- Spine Crush (Loyal Creation)
 	
 	-- id ?[320637] = 20, 		-- Fetid Gas (Blightbone)
+	[319897] = 20,      -- Land of the Dead (Amarth - summons Crossbowman)
+	[319902] = 20,      -- Land of the Dead (Amarth - summons Warrior)
+	[333627] = 20,      -- Land of the Dead (Amarth - summons Mage)
+	[321253] = 20,		-- Final Harvest (Amarth)
 	[333489] = 20,		-- Necrotic Breath (Amarth)
 	[333492] = 20,		-- Necrotic Ichor (Amarth apply by Necrotic Breath)
 	[320365] = 20,		-- Embalming Ichor (Surgeon Stitchflesh)
@@ -196,7 +204,7 @@ local Spells = {
 }
 
 local SpellsNoTank = {
-    -- Mists of Tirna Scythe
+    -- Mists of Tirna Scithe
 	[331721] = 20,      -- Spear Flurry (Mistveil Defender)
 	
 	-- De Other Side
@@ -204,7 +212,7 @@ local SpellsNoTank = {
 	-- Spires of Ascension
 	[317943] = 20,      -- Sweeping Blow (Frostsworn Vanguard)
 	
-	-- The Necrotic Wakes
+	-- The Necrotic Wake
 	[324323] = 20,		-- Gruesome Cleave (Skeletal Marauder)
 
 	-- Plaguefall
@@ -220,7 +228,7 @@ local SpellsNoTank = {
 }
 
 local Auras = {
-    -- Mists of Tirna Scythe
+    -- Mists of Tirna Scithe
     [323137] = true,      --- Bewildering Pollen (Drohman Oulfarran)
 	[321893] = true,      --- Freezing Burst (Illusionary Vulpin)
 	
@@ -230,7 +238,8 @@ local Auras = {
 	-- Spires of Ascension
 	[324205] = 20,        -- Blinding Flash (Ventunax)
 	
-	-- The Necrotic Wakes
+	-- The Necrotic Wake
+    [324293] = 20         -- Rasping Scream (Skeletal Marauder)
 	
 	-- Plaguefall
 	

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -63,6 +63,7 @@ local Spells = {
 	[321834] = 20,		-- Dodge Ball (Mistcaller)
 	[336759] = 20,		-- Dodge Ball (Mistcaller)
 	[321893] = 20,		-- Freezing Burst (Mistcaller)
+	[321828] = 20,		-- Patty Cake (Mistcaller)
 	[322655] = 20,		-- Acid Expulsion (Tred'ova)
 	[326309] = 20,		-- Decomposing Acid (Tred'ova)
 	[326263] = 20,		-- Anima Shedding (Tred'ova)

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -55,7 +55,7 @@ local Spells = {
 	[340311] = 20,      -- Crushing Leap (Mistveil Gorgegullet)
 	[331743] = 20,		-- Bucking Rampage (Mistveil Guardian)
 	[331748] = 20,      -- Back Kick (Mistveil Guardian)
-	--id ? [340160] = 20,		-- Radiant Breath (Mistveil Matriarch)
+	[340160] = 20,		-- Radiant Breath (Mistveil Matriarch)
 	
 	--id ? [323177] = 20,		-- Tears of the Forest(Ingra Maloch)
 	[323250] = 20,      -- Anima Puddle (Droman Oulfarran)
@@ -88,7 +88,6 @@ local Spells = {
 	
 	-- Spires of Ascension
 	--[323786] = 20,      -- Swift Slice (Kyrian Dark-Praetor)
-	[324608] = 20,      -- Charged Stomp (Oryphrion)
 	[323740] = 20,		-- Impact (Forsworn Squad-Leader)
 	[336447] = 20,		-- Crashing Strike (Forsworn Squad-Leader)
 	[336444] = 20,		-- Crescendo (Forsworn Helion)
@@ -211,6 +210,7 @@ local SpellsNoTank = {
 	
 	-- Spires of Ascension
 	[317943] = 20,      -- Sweeping Blow (Frostsworn Vanguard)
+    [324608] = 20,      -- Charged Stomp (Oryphrion)
 	
 	-- The Necrotic Wake
 	[324323] = 20,		-- Gruesome Cleave (Skeletal Marauder)

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -87,7 +87,7 @@ local Spells = {
 	[340026] = 20,		-- Wailing Grief (Mythresh, Sky's Talons)
 	[332729] = 20,		-- Malefic Blast (Environment - Dealer's Hallway)
 
-	[323992] = 20,		-- Echo Finger Laser X-treme (Millificent Manastorm)
+	[324010] = 20,		-- Eruption (Millificent Manastorm)
 	[320723] = 20,		-- Displaced Blastwave (Dealer Xy'exa)
 	[320727] = 20,		-- Displaced Blastwave (Dealer Xy'exa)
 	[320232] = 20,		-- Explosive Contrivance (Dealer Xy'exa)
@@ -619,16 +619,16 @@ end
 function ElitismFrame:ADDON_LOADED(event,addon)
 	if addon == "ElitismHelper" then	
 		ElitismFrame:RebuildTable()
-	end
-	
-	if not ElitismHelperDB then
-		ElitismHelperDB = defaultElitismHelperDBValues
-	end
 
-	-- Backwards compatibility to make sure that DB values will always be set, even when updating from previous versions
-	for key, defaultValue in pairs(defaultElitismHelperDBValues) do
-		if ElitismHelperDB[key] == nil then
-			ElitismHelperDB[key] = defaultValue
+		if not ElitismHelperDB then
+			ElitismHelperDB = defaultElitismHelperDBValues
+		end
+
+		-- Backwards compatibility to make sure that DB values will always be set, even when updating from previous versions
+		for key, defaultValue in pairs(defaultElitismHelperDBValues) do
+			if ElitismHelperDB[key] == nil then
+				ElitismHelperDB[key] = defaultValue
+			end
 		end
 	end
 end

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -107,9 +107,10 @@ local Spells = {
 	
 	-- The Necrotic Wake
 	[324391] = 20,		-- Frigid Spikes (Skeletal Monstrosity)
-	[324372] = 20,		-- Reaping Winds (Skeletal Monstrosity)
-	-- id ?[320574] = 20,		-- Shadow Well (Zolramus Sorcerer)
+	[324381] = 20,		-- Chill Scythe / Reaping Winds (Skeletal Monstrosity)
+	[320574] = 20,		-- Shadow Well (Zolramus Sorcerer)
 	[333477] = 20,		-- Gut Slice (Goregrind)
+    [345625] = 20,      -- Death Burst (Nar'zudah)
 	
 	-- id ?[320637] = 20, 		-- Fetid Gas (Blightbone)
 	[333489] = 20,		-- Necrotic Breath (Amarth)
@@ -118,8 +119,9 @@ local Spells = {
 	[320366] = 20,		-- Embalming Ichor (Surgeon Stitchflesh)
 	[327952] = 20,		-- Meat Hook (Stitchflesh)
 	[327100] = 20,      -- Noxious Fog (Stitchflesh)
-	[328212] = 20,      -- Razorshard Ice (Nalthor the Rimebender)
+	[328212] = 20,      -- Razorshard Ice (Nalthor the Rimebinder)
 	[320784] = 20,		-- Comet Storm (Nalthor the Rimebinder)
+	[321956] = 20,      -- Comet Storm (Nalthor the Rimebinder) (this one is for Dark Exiled players)
 	
 	-- Plaguefall
 	[320072] = 20, 		-- Toxic Pool (Decaying Flesh Giant)
@@ -144,6 +146,7 @@ local Spells = {
 	[336996] = 20,      -- Whirling Blade (Nekthara the Mangler) ?? TODO: Which one is correct?
 	[317605] = 20,      -- Whirlwind (Nekthara the Mangler and Rek the Hardened)
 	[332708] = 20,		-- Ground Smash (Heavin the Breaker)
+	[334025] = 20,		-- Bloodthirsty Charge (Haruga the Bloodthirsty)
 	[333297] = 20, 		-- Death Winds (Nefarious Darkspeaker)
 	[331243] = 20,		-- Bone Spikes (Soulforged Bonereaver)
 	[331224] = 20,		-- Bonestorm (Soulforged Bonereaver)
@@ -158,6 +161,7 @@ local Spells = {
 	[318406] = 20,		-- Tenderizing Smash (Gorechop)
 	[323406] = 20,      -- Jagged Gash (Gorechop)
 	-- id ?[323542] = 20,		-- Oozing (Gorechop)
+	[317367] = 20,      -- Necrotic Volley (Kul'tharok)
 	[323681] = 20,		-- Dark Devastation (Mordretha)
 	[339550] = 20,		-- Echo of Battle (Mordretha)
 	[323831] = 20,		-- Death Grasp (Mordretha)
@@ -167,8 +171,6 @@ local Spells = {
 	[334563] = 20,		-- Volatile Trap (Dreadful Huntmaster)
 	[320991] = 20,		-- Echoing Thrust (Regal Mistdancer)
 	[320999] = 20,		-- Echoing Thrust (Regal Mistdancer Mirror)
-	-- id ?[321019] = 20,		-- Sanctified Mists (Regal Mistcaller)
-	-- [334921] = 20,		-- Umbral Crash (Insatiable Brute)
 	[322418] = 20,		-- Craggy Fracture (Chamber Sentinel)
 	[334378] = 20,      -- Explosive Vellum (Research Scribe)
 	[323573] = 20,      -- Residue (Fleeting Manifestation)
@@ -212,7 +214,7 @@ local SpellsNoTank = {
 	-- Sanguine Depths
 	
 	-- Hall of Atonement 
-	--[323001] = 20,      -- Glass Shards (Halkias)
+	--[323001] = 20,      -- Glass Shards (Halkias) This is always unavoidable for tanks but sometimes unavoidable for everyone
 	[322936] = 20,      -- Crumbling Slam (Halkias)
 	[346866] = 20, 		-- Stone Breath (Loyal Stoneborn)
 }

--- a/ElitismHelper.toc
+++ b/ElitismHelper.toc
@@ -1,6 +1,7 @@
-## Interface: 90005
+## Interface: 90105
 ## Title: ElitismHelper
-## Version: 0.10.0
+## Version: 0.11.0
 ## Notes: Helps with being an elitist by calling out fails
 ## SavedVariables: ElitismHelperDB
+
 ElitismHelper.lua

--- a/ElitismHelper.toc
+++ b/ElitismHelper.toc
@@ -1,4 +1,4 @@
-## Interface: 90105
+## Interface: 90200
 ## Title: ElitismHelper
 ## Version: 0.11.0
 ## Notes: Helps with being an elitist by calling out fails


### PR DESCRIPTION
- Added avoidable damage from Tormented mobs
- Added some missing avoidable damage in MotS
- Removed unavoidable Swift Slice in SoA
- Added a lot of avoidable damage in ToP
- Removed unavoidable Echoes of Carnage in ToP (probably meant Echo of Battle, which was added)
- Added avoidable damage in HoA
- Tweaked which spells are considered reasonably unavoidable for tanks