### PR TITLE
Support for Dragonflight Dungeons Season 1

### DIFF
--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -318,7 +318,7 @@ local Spells = {
 	[351646] = 20,		-- Hyperlight Nova (So'leah)
 	
 	-- [**Legion**] 
-	--Court of Stars
+	-- Court of Stars
 	[219498] = 20,		-- Streetsweeper (Patrol Captain Gerdo)
 	[206574] = 20,		-- Resonant Slash (Patrol Captain Gerdo)
 	[206580] = 20,		-- Resonant Slash (Patrol Captain Gerdo)
@@ -335,6 +335,17 @@ local Spells = {
 	[193234] = 20,		-- Dancing Blade (Hymdall)
 	[193260] = 20,		-- Static Field (Storm Drake, Hymdall)
 	[188395] = 20,		-- Ball Lightning (Static Field, Hymdall)
+
+	
+	-- [**Mist of Pandaria**] 
+	-- Temple of the Jade Serpent
+	[115167] = 20, 		-- Corrupted Waters (Wise Mari)
+	[106334] = 20, 		-- Wash Away (Wise Mari)
+	[106938] = 20, 		-- Serpent Wave (Liu FlameHeart)
+	[107053] = 20, 		-- Jade Serpent Wave (Liu FlameHeart)
+	[107045] = 20, 		-- Jade Fire (Liu FlameHeart)
+	
+	
 		
 }
 

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -51,15 +51,19 @@ local Spells = {
 	[373429] = 20,		-- Carrion Swarm (Season 4 Nathrezim Infiltrator)
 
 	-- [**Dragonflight**]
-	
 	-- Algeh'ar Academy S1
 	[386201] = 20,		-- Corruped Mana (Vexamus)
 	[388796] = 20,		-- Germinate (Overgrown Ancient)
 	[374361] = 20,		-- Astral Breath (Echo of Doragosa)
 	
 	-- Brackenhide Hollow
+	[376811] = 20,		-- Decay spray (Treemouth)	
+	[376170] = 20,		-- Choking Rotcloud (Decatriarch Wratheye)
 	
 	-- Hall Of Infusion
+	[375215] = 20,		-- Cave in (Gulping Goliath)
+	[390006] = 20,		-- Frost Cyclone (Khajin the Unyielding)
+	[388786] = 20,		-- Rogue Waves (Primal Tsunami)
 	
 	-- Neltharus 
 	[374854] = 20, 		-- Erupted Ground (Chargath, bane of Scales)
@@ -81,12 +85,11 @@ local Spells = {
 	[382670] = 20,		-- Gale Arrow (Teera and Maruuk)
 	[376683] = 20,		-- Iron Stampede (Balakar Khan)
 	[393421] = 20,		-- Quake (Balakar Khan)
+	
 	-- Uldaman : Legacy of Tyr
 	
 	
 	-- [**Shadowlands**]
-
-
 	-- Mists of Tirna Scithe
 	[321968] = 20,		-- Bewildering Pollen (Tirnenn Villager)
 	[323137] = 20,		-- Bewildering Pollen (Tirnenn Villager)
@@ -348,12 +351,8 @@ local Spells = {
 	[106938] = 20, 		-- Serpent Wave (Liu FlameHeart)
 	[107053] = 20, 		-- Jade Serpent Wave (Liu FlameHeart)
 	[107045] = 20, 		-- Jade Fire (Liu FlameHeart)
-	
-	
 		
 }
-
-
 
 local SpellsNoTank = {
 	-- Mists of Tirna Scithe

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -316,7 +316,29 @@ local Spells = {
 	--[?] = 20,			-- Deadly Seas (Timecap'n Hooktail) (oneshot from going in water, debuff?)
 	[351101] = 20,		-- Energy Fragmentation (So'leah)
 	[351646] = 20,		-- Hyperlight Nova (So'leah)
+	
+	-- [**Legion**] 
+	--Court of Stars
+	[219498] = 20,		-- Streetsweeper (Patrol Captain Gerdo)
+	[206574] = 20,		-- Resonant Slash (Patrol Captain Gerdo)
+	[206580] = 20,		-- Resonant Slash (Patrol Captain Gerdo)
+	[209477] = 20,		-- Wild Detonation (Mana Wyrm)
+	[211457] = 20,		-- Infernal Eruption (Talixae Flamewreath)
+	[209630] = 20,		-- Piercing Gale (Images of Advisor Melandrus)
+	[209628] = 20,		-- Piercing Gale (Advisor Melandrus)
+	[214688] = 20,		-- Carrion Swarm (Gerenth the Vile)
+	
+	-- Halls of Valor
+	[192206] = 20,		-- Sanctify (Olmyr & Hyrja)
+	[199210] = 20,		-- Penetrating Shot (Valarjar Marksman)
+	[210875] = 20,		-- Charged Pulse (Stormforged Sentinel)
+	[193234] = 20,		-- Dancing Blade (Hymdall)
+	[193260] = 20,		-- Static Field (Storm Drake, Hymdall)
+	[188395] = 20,		-- Ball Lightning (Static Field, Hymdall)
+		
 }
+
+
 
 local SpellsNoTank = {
 	-- Mists of Tirna Scithe

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -73,6 +73,7 @@ local Spells = {
 	-- The Azure Vault 
 	[385578] = 20,		-- Arcane Orb (AzureBlade)
 	[372222] = 20,		-- Arcane Slicer (AzureBlade)
+	[384699] = 20,		-- Crystalline Roar (Umbrelskul)
 
 	-- The Nokhud Offensive
 	[384186] = 20,		-- Lighting Strike (The Raging Tempest)

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -335,7 +335,11 @@ local Spells = {
 	[193234] = 20,		-- Dancing Blade (Hymdall)
 	[193260] = 20,		-- Static Field (Storm Drake, Hymdall)
 	[188395] = 20,		-- Ball Lightning (Static Field, Hymdall)
-
+	
+	-- [**Warlords of Draenor**] 
+	-- Shadowmoon Burial Grounds
+	[153395] = 20,		-- Body Slam (Bonemaw)
+	[154442] = 20,		-- %amevpme,ce (Ner'zhul)
 	
 	-- [**Mist of Pandaria**] 
 	-- Temple of the Jade Serpent

--- a/ElitismHelper.lua
+++ b/ElitismHelper.lua
@@ -37,17 +37,53 @@ local Spells = {
 	[343520] = 20,		-- Storming (Environment)
 	[350163] = 20,		-- Melee (Spiteful Shade)
 
-	[342494] = 20,		-- Belligerent Boast (Season 1 Prideful)
-	[356414] = 20,		-- Frost Lance (Season 2 Oros)
-	[358894] = 20,		-- Cold Snap (Season 2 Oros)
-	[358897] = 20,		-- Cold Snap (Season 2 Oros)
-	[355806] = 20,		-- Massive Smash (Season 2 Soggodon)
-	[355737] = 20,		-- Scorching Blast (Season 2 Arkolath)
-	[355738] = 20,		-- Scorching Blast DoT (Season 2 Arkolath)
-	[366288] = 20,		-- Force Slam (Season 3 Urh Dismantler)
-	[366409] = 20,		-- Fusion Beam (Season 3 Vy Interceptor)
+	--[342494] = 20,		-- Belligerent Boast (Season 1 Prideful)
+	--[356414] = 20,		-- Frost Lance (Season 2 Oros)
+	--[358894] = 20,		-- Cold Snap (Season 2 Oros)
+	--[358897] = 20,		-- Cold Snap (Season 2 Oros)
+	--[355806] = 20,		-- Massive Smash (Season 2 Soggodon)
+	--[355737] = 20,		-- Scorching Blast (Season 2 Arkolath)
+	--[355738] = 20,		-- Scorching Blast DoT (Season 2 Arkolath)
+	--[366288] = 20,		-- Force Slam (Season 3 Urh Dismantler)
+	--[366409] = 20,		-- Fusion Beam (Season 3 Vy Interceptor)
+	
 	[373513] = 20,		-- Shadow Eruption (Season 4 Zul'gamux)
 	[373429] = 20,		-- Carrion Swarm (Season 4 Nathrezim Infiltrator)
+
+	-- [**Dragonflight**]
+	
+	-- Algeh'ar Academy S1
+	[386201] = 20,		-- Corruped Mana (Vexamus)
+	[388796] = 20,		-- Germinate (Overgrown Ancient)
+	[374361] = 20,		-- Astral Breath (Echo of Doragosa)
+	
+	-- Brackenhide Hollow
+	
+	-- Hall Of Infusion
+	
+	-- Neltharus 
+	[374854] = 20, 		-- Erupted Ground (Chargath, bane of Scales)
+	[373767] = 20,		-- Magma Wave (Chargath, bane of Scales)
+	[377995] = 20,		-- Forgestorm (Forgemaster Gorek)
+	[377204] = 20,		-- Berserk Barrage (Warlord Sargha)
+	
+	-- Ruby Life Pools 
+	[372107] = 20,		-- Molten Boulder (Kokia Blazehoof)
+	
+	-- The Azure Vault 
+	[385578] = 20,		-- Arcane Orb (AzureBlade)
+	[372222] = 20,		-- Arcane Slicer (AzureBlade)
+
+	-- The Nokhud Offensive
+	[384186] = 20,		-- Lighting Strike (The Raging Tempest)
+	[385339] = 20,		-- Earthsplitter (Teera and Maruuk)
+	[382670] = 20,		-- Gale Arrow (Teera and Maruuk)
+	[376683] = 20,		-- Iron Stampede (Balakar Khan)
+	[393421] = 20,		-- Quake (Balakar Khan)
+	-- Uldaman : Legacy of Tyr
+	
+	
+	-- [**Shadowlands**]
 
 
 	-- Mists of Tirna Scithe
@@ -71,8 +107,7 @@ local Spells = {
 	[322655] = 20,		-- Acid Expulsion (Tred'ova)
 	[326309] = 20,		-- Decomposing Acid (Tred'ova)
 	[326263] = 20,		-- Anima Shedding (Tred'ova)
-
-
+	
 	-- De Other Side
 	[334051] = 20,		-- Erupting Darkness (Death Speaker)
 	[328729] = 20,		-- Dark Lotus (Risen Cultist)


### PR DESCRIPTION
New dungeons DF 

- Ruby Life Pools
- The Nokhud Offensive
- The Azure Vault
- Algeth’ar Academy
- Uldaman : Legacy of Tyr
- Neltharus
- Brackenhide Hollow
- Hall Of Infusion 

New dungeon rotation :

- Halls of Valor (from the Legion expansion)
- Court of Stars (from the Legion expansion)
- Shadowmoon Burial Grounds (from the Warlords of Draenor expansion)
- Temple of the Jade Serpent (from the Mists of Pandaria expansion)